### PR TITLE
Second try to run tests on crowdin PR's

### DIFF
--- a/.github/workflows/_check-php-code.yml
+++ b/.github/workflows/_check-php-code.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     branches:
       - main
-    types: [synchronize, opened]
+  workflow_run:
+    workflows: ["J4 Download Package Translations Crowdin Action"]
+    types: [completed]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 env:
@@ -12,8 +14,9 @@ env:
 
 jobs:
   check-php-code:
-    if: (github.event_name == 'pull_request' && github.repository == 'joomla/core-translations') || (github.event_name == 'push' && github.repository == 'joomla/core-translations') || (github.event_name != 'schedule')
+    if: (github.repository == 'joomla/core-translations') || (github.repository != 'joomla/core-translations' && github.event_name != 'schedule')
     runs-on: ubuntu-latest
+    permissions: read-all
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v3

--- a/.github/workflows/_en-gb-localise.yml
+++ b/.github/workflows/_en-gb-localise.yml
@@ -4,13 +4,16 @@ on:
   pull_request:
     branches:
       - main
-    types: [synchronize, opened]
+  workflow_run:
+    workflows: ["J4 Download Package Translations Crowdin Action"]
+    types: [completed]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
   engb-localise:
     runs-on: ubuntu-latest
+    permissions: read-all
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/_pr-comment.yml
+++ b/.github/workflows/_pr-comment.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   comment:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:
       - name: on artifact


### PR DESCRIPTION
Test are not running on crowdin PR's because of decision taken by actions team see https://github.com/peter-evans/create-pull-request/issues/48#issuecomment-537478081 but when that comment from GH support was posted `workflow_run` trigger did not exist yet. I'm adding also permissions because workflows running on workflow_run have write permissions by default.