### PR TITLE
Revert usu of `workflow_run` for crowdin PR's

### DIFF
--- a/.github/workflows/_check-php-code.yml
+++ b/.github/workflows/_check-php-code.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  workflow_run:
-    workflows: ["J4 Download Package Translations Crowdin Action"]
-    types: [completed]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 env:
@@ -16,26 +13,9 @@ jobs:
   check-php-code:
     if: (github.repository == 'joomla/core-translations') || (github.repository != 'joomla/core-translations' && github.event_name != 'schedule')
     runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-      issues: write
-      pull-requests: write
-      contents: read
+    permissions: read-all
 
     steps:
-      - name: Get crowdin PR details
-        uses: xt0rted/pull-request-comment-branch@v1.3.0
-        if: github.event_name == 'workflow_run'
-        id: pr-details
-      - name: Set commit status as pending
-        uses: myrotvorets/set-commit-status-action@1.1.5
-        if: github.event_name == 'workflow_run'
-        with:
-          sha: ${{ steps.pr-details.outputs.head_sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: pending
-          targetUrl: ${{ job.html_url }}
-
       - name: Checkout Source Code
         uses: actions/checkout@v3
         with:
@@ -45,13 +25,4 @@ jobs:
         uses: StephaneBour/actions-php-lint@7.4
         with:
           dir: '.'
-
-      - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@1.1.5
-        if: always() && github.event_name == 'workflow_run'
-        with:
-          sha: ${{ steps.pr-details.outputs.head_sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}
-          targetUrl: ${{ job.html_url }}
 

--- a/.github/workflows/_en-gb-localise.yml
+++ b/.github/workflows/_en-gb-localise.yml
@@ -4,35 +4,15 @@ on:
   pull_request:
     branches:
       - main
-  workflow_run:
-    workflows: ["J4 Download Package Translations Crowdin Action"]
-    types: [completed]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
   engb-localise:
     runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-      issues: write
-      pull-requests: write
-      contents: read
+    permissions: read-all
 
     steps:
-      - name: Get crowdin PR details
-        uses: xt0rted/pull-request-comment-branch@v1.3.0
-        if: github.event_name == 'workflow_run'
-        id: pr-details
-      - name: Set commit status as pending
-        uses: myrotvorets/set-commit-status-action@1.1.5
-        if: github.event_name == 'workflow_run'
-        with:
-          sha: ${{ steps.pr-details.outputs.head_sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: pending
-          targetUrl: ${{ job.html_url }}
-
       - name: Checkout Source Code
         uses: actions/checkout@v3
       - name: Check PR content
@@ -76,13 +56,4 @@ jobs:
         with:
           name: En_GBLocalise-logs
           path: ./joomla_v4/translations/package/logs
-          
-      - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@1.1.5
-        if: always() && github.event_name == 'workflow_run'
-        with:
-          sha: ${{ steps.pr-details.outputs.head_sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}
-          targetUrl: ${{ job.html_url }}
 

--- a/.github/workflows/_jexec_translations.yml
+++ b/.github/workflows/_jexec_translations.yml
@@ -4,35 +4,16 @@ on:
   pull_request:
     branches:
       - main
-  workflow_run:
-    workflows: ["J4 Download Package Translations Crowdin Action"]
-    types: [completed]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
   no-jexec:
     runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-      issues: write
-      pull-requests: write
-      contents: read
+    permissions: read-all
 
     steps:
-      - name: Get crowdin PR details
-        uses: xt0rted/pull-request-comment-branch@v1.3.0
-        if: github.event_name == 'workflow_run'
-        id: pr-details
-      - name: Set commit status as pending
-        uses: myrotvorets/set-commit-status-action@1.1.5
-        if: github.event_name == 'workflow_run'
-        with:
-          sha: ${{ steps.pr-details.outputs.head_sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: pending
-          targetUrl: ${{ job.html_url }}
-
+    
       - name: Checkout Source Code
         uses: actions/checkout@v3
       - name: Check PR content
@@ -77,11 +58,3 @@ jobs:
           name: JEXEC-logs
           path: ./joomla_v4/translations/package/logs
 
-      - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@1.1.5
-        if: always() && github.event_name == 'workflow_run'
-        with:
-          sha: ${{ steps.pr-details.outputs.head_sha }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}
-          targetUrl: ${{ job.html_url }}


### PR DESCRIPTION
This PR revert use of `workflow_run` for the crowdin PR's. Instead of that we should use custom PAT in `crowdin-v4-dl-package-translations.yml` workflow.

references
https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow