### PR TITLE
Update fjogeleit/http-request-action to v1.11.1

### DIFF
--- a/.github/workflows/crowdin-v3-buildproject.yml
+++ b/.github/workflows/crowdin-v3-buildproject.yml
@@ -15,7 +15,7 @@ jobs:
     # Runs the HTTP Request action command - https://github.com/fjogeleit/http-request-action
     - name: Call build URL
       id: BuildV3CMS
-      uses: fjogeleit/http-request-action@master
+      uses: fjogeleit/http-request-action@v1.11.1
       with:
         url: 'https://crowdin.com/api/v2/projects/120642/translations/builds'
         method: 'POST'

--- a/.github/workflows/crowdin-v4-buildproject.yml
+++ b/.github/workflows/crowdin-v4-buildproject.yml
@@ -15,7 +15,7 @@ jobs:
     # Runs the HTTP Request action command - https://github.com/fjogeleit/http-request-action
     - name: Call build URL
       id: BuildV4CMS
-      uses: fjogeleit/http-request-action@master
+      uses: fjogeleit/http-request-action@v1.11.1
       with:
         url: 'https://joomla.crowdin.com/api/v2/projects/18/translations/builds'
         method: 'POST'


### PR DESCRIPTION
This resolves https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for this action and gives control to dependabot