### PR TITLE
Update GitHub Workflows for Joomla_V5

### DIFF
--- a/.github/workflows/_check-php-code.yml
+++ b/.github/workflows/_check-php-code.yml
@@ -6,7 +6,8 @@ on:
       - main
   push:
     branches:
-      - l10n_crowdin_action
+      - l10n_crowdin_package_v4
+      - l10n_crowdin_package_v5
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 env:

--- a/.github/workflows/_en-gb-localise.yml
+++ b/.github/workflows/_en-gb-localise.yml
@@ -6,7 +6,7 @@ on:
       - main
   push:
     branches:
-      - l10n_crowdin_action
+      - l10n_crowdin_package_v4
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/_jexec_translations.yml
+++ b/.github/workflows/_jexec_translations.yml
@@ -6,7 +6,7 @@ on:
       - main
   push:
     branches:
-      - l10n_crowdin_action
+      - l10n_crowdin_package_v4
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/_long-arrays-localise.yml
+++ b/.github/workflows/_long-arrays-localise.yml
@@ -6,7 +6,7 @@ on:
       - main
   push:
     branches:
-      - l10n_crowdin_action
+      - l10n_crowdin_package_v4
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/core-get-language-source-v4.yml
+++ b/.github/workflows/core-get-language-source-v4.yml
@@ -31,27 +31,34 @@ jobs:
         # We use a simple copy paste syntax here if needed customization for different directories
         run: |
           cd ..
+          REPO_NAME=${{ github.event.repository.name }}
           SYNC_VERION="v4"
 
           SYNC_PATH="administrator/language/en-GB/"
           echo /${SYNC_PATH}
-          rsync -i -rptgo --checksum --ignore-times --delete  joomla-cms/${SYNC_PATH} core-translations/joomla_${SYNC_VERION}/source/${SYNC_PATH}
+          mkdir -p ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_PATH}
+          rsync -i -rptgo --checksum --ignore-times --delete joomla-cms/${SYNC_PATH} ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_PATH}
 
-          SYNC_PATH="administrator/manifests/packages/pkg_en-GB.xml"
-          echo /${SYNC_PATH}
-          rsync -i -rptgo --checksum --ignore-times --delete  joomla-cms/${SYNC_PATH} core-translations/joomla_${SYNC_VERION}/source/${SYNC_PATH}
+          SYNC_PATH="administrator/manifests/packages/"
+          SYNC_FILE="administrator/manifests/packages/pkg_en-GB.xml"
+          echo /${SYNC_FILE}
+          mkdir -p ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_PATH}
+          rsync -i -rptgo --checksum --ignore-times --delete joomla-cms/${SYNC_FILE} ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_FILE}
 
           SYNC_PATH="api/language/en-GB/"
           echo /${SYNC_PATH}
-          rsync -i -rptgo --checksum --ignore-times --delete  joomla-cms/${SYNC_PATH} core-translations/joomla_${SYNC_VERION}/source/${SYNC_PATH}
+          mkdir -p ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_PATH}
+          rsync -i -rptgo --checksum --ignore-times --delete joomla-cms/${SYNC_PATH} ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_PATH}
 
           SYNC_PATH="installation/language/en-GB/"
           echo /${SYNC_PATH}
-          rsync -i -rptgo --checksum --ignore-times --delete  joomla-cms/${SYNC_PATH} core-translations/joomla_${SYNC_VERION}/source/${SYNC_PATH}
+          mkdir -p ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_PATH}
+          rsync -i -rptgo --checksum --ignore-times --delete joomla-cms/${SYNC_PATH} ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_PATH}
 
           SYNC_PATH="language/en-GB/"
           echo /${SYNC_PATH}
-          rsync -i -rptgo --checksum --ignore-times --delete  joomla-cms/${SYNC_PATH} core-translations/joomla_${SYNC_VERION}/source/${SYNC_PATH}
+          mkdir -p ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_PATH}
+          rsync -i -rptgo --checksum --ignore-times --delete joomla-cms/${SYNC_PATH} ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_PATH}
 
       - name: Push j4 to repo
         run: |
@@ -69,27 +76,27 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - name: Checkout
-      uses: actions/checkout@v4
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    # Runs the Crowdin action command - https://github.com/crowdin/github-action
-    - name: crowdin action package files
-      uses: crowdin/github-action@v1.13.1
-      with:
-        # Upload sources to Crowdin
-        upload_sources: true
-        # Option to specify a path to the configuration file, without / at the beginning
-        config: 'Configurations/Crowdin-J4-All.yml'
-        # Use true for dryrun to test the run without actually processing anything
-        dryrun_action: false
+      # Runs the Crowdin action command - https://github.com/crowdin/github-action
+      - name: crowdin action package files
+        uses: crowdin/github-action@v1.13.1
+        with:
+          # Upload sources to Crowdin
+          upload_sources: true
+          # Option to specify a path to the configuration file, without / at the beginning
+          config: 'Configurations/Crowdin-J4-All.yml'
+          # Use true for dryrun to test the run without actually processing anything
+          dryrun_action: false
 
-    - name: crowdin action installer files
-      uses: crowdin/github-action@v1.13.1
-      with:
-        # Upload sources to Crowdin
-        upload_sources: true
-        # Option to specify a path to the configuration file, without / at the beginning
-        config: 'Configurations/Crowdin-J4-Installer.yml'
-        # Use true for dryrun to test the run without actually processing anything
-        dryrun_action: false
+      - name: crowdin action installer files
+        uses: crowdin/github-action@v1.13.1
+        with:
+          # Upload sources to Crowdin
+          upload_sources: true
+          # Option to specify a path to the configuration file, without / at the beginning
+          config: 'Configurations/Crowdin-J4-Installer.yml'
+          # Use true for dryrun to test the run without actually processing anything
+          dryrun_action: false

--- a/.github/workflows/core-get-language-source-v5.yml
+++ b/.github/workflows/core-get-language-source-v5.yml
@@ -31,33 +31,34 @@ jobs:
         # We use a simple copy paste syntax here if needed customization for different directories
         run: |
           cd ..
+          REPO_NAME=${{ github.event.repository.name }}
           SYNC_VERION="v5"
 
           SYNC_PATH="administrator/language/en-GB/"
           echo /${SYNC_PATH}
-          mkdir -p core-translations/joomla_${SYNC_VERION}/source/${SYNC_PATH}
-          rsync -i -rptgo --checksum --ignore-times --delete  joomla-cms/${SYNC_PATH} core-translations/joomla_${SYNC_VERION}/source/${SYNC_PATH}
+          mkdir -p ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_PATH}
+          rsync -i -rptgo --checksum --ignore-times --delete joomla-cms/${SYNC_PATH} ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_PATH}
 
           SYNC_PATH="administrator/manifests/packages/"
           SYNC_FILE="administrator/manifests/packages/pkg_en-GB.xml"
           echo /${SYNC_FILE}
-          mkdir -p core-translations/joomla_${SYNC_VERION}/source/${SYNC_PATH}
-          rsync -i -rptgo --checksum --ignore-times --delete  joomla-cms/${SYNC_FILE} core-translations/joomla_${SYNC_VERION}/source/${SYNC_FILE}
+          mkdir -p ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_PATH}
+          rsync -i -rptgo --checksum --ignore-times --delete joomla-cms/${SYNC_FILE} ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_FILE}
 
           SYNC_PATH="api/language/en-GB/"
           echo /${SYNC_PATH}
-          mkdir -p core-translations/joomla_${SYNC_VERION}/source/${SYNC_PATH}
-          rsync -i -rptgo --checksum --ignore-times --delete  joomla-cms/${SYNC_PATH} core-translations/joomla_${SYNC_VERION}/source/${SYNC_PATH}
+          mkdir -p ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_PATH}
+          rsync -i -rptgo --checksum --ignore-times --delete joomla-cms/${SYNC_PATH} ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_PATH}
 
           SYNC_PATH="installation/language/en-GB/"
           echo /${SYNC_PATH}
-          mkdir -p core-translations/joomla_${SYNC_VERION}/source/${SYNC_PATH}
-          rsync -i -rptgo --checksum --ignore-times --delete  joomla-cms/${SYNC_PATH} core-translations/joomla_${SYNC_VERION}/source/${SYNC_PATH}
+          mkdir -p ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_PATH}
+          rsync -i -rptgo --checksum --ignore-times --delete joomla-cms/${SYNC_PATH} ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_PATH}
 
           SYNC_PATH="language/en-GB/"
           echo /${SYNC_PATH}
-          mkdir -p core-translations/joomla_${SYNC_VERION}/source/${SYNC_PATH}
-          rsync -i -rptgo --checksum --ignore-times --delete  joomla-cms/${SYNC_PATH} core-translations/joomla_${SYNC_VERION}/source/${SYNC_PATH}
+          mkdir -p ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_PATH}
+          rsync -i -rptgo --checksum --ignore-times --delete joomla-cms/${SYNC_PATH} ${REPO_NAME}/joomla_${SYNC_VERION}/source/${SYNC_PATH}
 
       - name: Push j5 to repo
         run: |
@@ -75,31 +76,31 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - name: Checkout
-      uses: actions/checkout@v4
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    # Runs the Crowdin action command - https://github.com/crowdin/github-action
-    - name: crowdin action package files
-      uses: crowdin/github-action@v1.13.1
-      with:
-        # Upload sources to Crowdin
-        upload_sources: true
-        # Option to specify a path to the configuration file, without / at the beginning
-        config: 'Configurations/Crowdin-J5-All.yml'
-        # Upload sources to Crowdin branch
-        crowdin_branch_name: JoomlaV5
-        # Use true for dryrun to test the run without actually processing anything
-        dryrun_action: false
+      # Runs the Crowdin action command - https://github.com/crowdin/github-action
+      - name: crowdin action package files
+        uses: crowdin/github-action@v1.13.1
+        with:
+          # Upload sources to Crowdin
+          upload_sources: true
+          # Option to specify a path to the configuration file, without / at the beginning
+          config: 'Configurations/Crowdin-J5-All.yml'
+          # Upload sources to Crowdin branch
+          crowdin_branch_name: JoomlaV5
+          # Use true for dryrun to test the run without actually processing anything
+          dryrun_action: false
 
-    - name: crowdin action installer files
-      uses: crowdin/github-action@v1.13.1
-      with:
-        # Upload sources to Crowdin
-        upload_sources: true
-        # Upload sources to Crowdin branch
-        crowdin_branch_name: JoomlaV5
-        # Option to specify a path to the configuration file, without / at the beginning
-        config: 'Configurations/Crowdin-J5-Installer.yml'
-        # Use true for dryrun to test the run without actually processing anything
-        dryrun_action: false
+      - name: crowdin action installer files
+        uses: crowdin/github-action@v1.13.1
+        with:
+          # Upload sources to Crowdin
+          upload_sources: true
+          # Option to specify a path to the configuration file, without / at the beginning
+          config: 'Configurations/Crowdin-J5-Installer.yml'
+          # Upload sources to Crowdin branch
+          crowdin_branch_name: JoomlaV5
+          # Use true for dryrun to test the run without actually processing anything
+          dryrun_action: false

--- a/.github/workflows/crowdin-v4-dl-installer-translations.yml
+++ b/.github/workflows/crowdin-v4-dl-installer-translations.yml
@@ -32,7 +32,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Afrikaans Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       #      "LanguageName": "Amharic",
       #      "CrowdinID": "am"
@@ -47,7 +47,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Arabic Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       #      "LanguageName": "Armenian",
       #      "CrowdinID": "hy"
@@ -65,7 +65,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Basque Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       #      "LanguageName": "Bengali",
       #      "CrowdinID": "bn"
@@ -83,7 +83,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Bulgarian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Catalan
         uses: crowdin/github-action@v1.13.1
@@ -95,7 +95,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Catalan Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Chinese Simplified
         uses: crowdin/github-action@v1.13.1
@@ -107,7 +107,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Chinese Simplified Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Chinese Traditional
         uses: crowdin/github-action@v1.13.1
@@ -119,7 +119,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Chinese Traditional Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Croatian
         uses: crowdin/github-action@v1.13.1
@@ -131,7 +131,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Croatian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Czech
         uses: crowdin/github-action@v1.13.1
@@ -143,7 +143,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Czech Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Danish
         uses: crowdin/github-action@v1.13.1
@@ -155,7 +155,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Danish Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Dari
         uses: crowdin/github-action@v1.13.1
@@ -167,7 +167,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Dari Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Dutch
         uses: crowdin/github-action@v1.13.1
@@ -179,7 +179,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Dutch Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Dutch Belgium
         uses: crowdin/github-action@v1.13.1
@@ -191,7 +191,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Dutch Belgium Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download English Australia
         uses: crowdin/github-action@v1.13.1
@@ -203,7 +203,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New English Australia Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download English Canada
         uses: crowdin/github-action@v1.13.1
@@ -215,7 +215,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New English Canada Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download English New Zealand
         uses: crowdin/github-action@v1.13.1
@@ -227,7 +227,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New English New Zealand Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       #      "LanguageName": "English South Africa",
       #      "CrowdinID": "en-ZA"
@@ -242,7 +242,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New English US Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       #      "LanguageName": "Esperanto",
       #      "CrowdinID": "eo"
@@ -257,7 +257,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Estonian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Finnish
         uses: crowdin/github-action@v1.13.1
@@ -269,7 +269,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Finnish Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download French
         uses: crowdin/github-action@v1.13.1
@@ -281,7 +281,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New French Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       #      "LanguageName": "French, Canada",
       #      "CrowdinID": "fr-CA"
@@ -299,7 +299,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Georgian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       # German doesn't use Crowdin
       # German Austria doesn't use Crowdin
@@ -317,7 +317,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Greek Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       #      "LanguageName": "Gujarati",
       #      "CrowdinID": "gu"
@@ -332,7 +332,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Hebrew Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       #      "LanguageName": "Hindi",
       #      "CrowdinID": "hi"
@@ -347,7 +347,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Hungarian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Indonesian
         uses: crowdin/github-action@v1.13.1
@@ -359,7 +359,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Indonesian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       #      "LanguageName": "Irish",
       #      "CrowdinID": "ga"
@@ -374,7 +374,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Italian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Japanese
         uses: crowdin/github-action@v1.13.1
@@ -386,7 +386,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Japanese Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Kazakh
         uses: crowdin/github-action@v1.13.1
@@ -398,7 +398,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Kazakh Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       #      "LanguageName": "Khmer",
       #      "CrowdinID": "km"
@@ -422,7 +422,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Latvian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Lithuanian
         uses: crowdin/github-action@v1.13.1
@@ -434,7 +434,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Lithuanian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Macedonian
         uses: crowdin/github-action@v1.13.1
@@ -446,7 +446,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Macedonian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       #      "LanguageName": "Malay",
       #      "CrowdinID": "ms"
@@ -471,7 +471,7 @@ jobs:
       #        skip_untranslated_strings: true
       #        export_only_approved: true
       #        commit_message: 'New Norwegian Bokmal Crowdin translations by Github Action'
-      #        localization_branch_name: 'l10n_crowdin_installer'
+      #        localization_branch_name: 'l10n_crowdin_installer_v4'
 
       #      "LanguageName": "Norwegian Nynorsk",
       #      "CrowdinID": "nn-NO"
@@ -492,7 +492,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Persian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Polish
         uses: crowdin/github-action@v1.13.1
@@ -504,7 +504,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Polish Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Portuguese
         uses: crowdin/github-action@v1.13.1
@@ -516,7 +516,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Portuguese Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Portuguese, Brazilian
         uses: crowdin/github-action@v1.13.1
@@ -528,7 +528,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Portuguese, Brazilian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Romanian
         uses: crowdin/github-action@v1.13.1
@@ -540,7 +540,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Romanian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       # Russian doesn't use Crowdin
       # - name: Crowdin Download Russian
@@ -553,7 +553,7 @@ jobs:
       #    skip_untranslated_strings: true
       #    export_only_approved: true
       #    commit_message: 'New Russian Crowdin translations by Github Action'
-      #    localization_branch_name: 'l10n_crowdin_installer'
+      #    localization_branch_name: 'l10n_crowdin_installer_v4'
 
       # Joomla INI not ready yet
       # - name: Crowdin Download Serbian (Cyrillic)
@@ -566,7 +566,7 @@ jobs:
       #    skip_untranslated_strings: true
       #    export_only_approved: true
       #    commit_message: 'New Serbian Cyrillic Crowdin translations by Github Action'
-      #    localization_branch_name: 'l10n_crowdin_installer'
+      #    localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Serbian (Latin)
         uses: crowdin/github-action@v1.13.1
@@ -578,7 +578,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Serbian Latin Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       #      "LanguageName": "Sinhala",
       #      "CrowdinID": "si"
@@ -593,7 +593,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Slovak Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Slovenian
         uses: crowdin/github-action@v1.13.1
@@ -605,7 +605,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Slovenian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Spanish
         uses: crowdin/github-action@v1.13.1
@@ -617,7 +617,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Spanish Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       #      "LanguageName": "Spanish, Colombia",
       #      "CrowdinID": "es-CO"
@@ -638,7 +638,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Swedish Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       #      "LanguageName": "Syriac",
       #      "CrowdinID": "syc"
@@ -656,7 +656,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Tamil Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Thai
         uses: crowdin/github-action@v1.13.1
@@ -668,7 +668,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Thai Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Turkish
         uses: crowdin/github-action@v1.13.1
@@ -680,7 +680,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Turkish Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       #      "LanguageName": "Turkmen",
       #      "CrowdinID": "tk"
@@ -695,7 +695,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Ukrainian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       #      "LanguageName": "Urdu (India)",
       #      "CrowdinID": "ur-IN"
@@ -710,7 +710,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Urdu (Pakistan) Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       #      "LanguageName": "Uyghur",
       #      "CrowdinID": "ug"
@@ -725,7 +725,7 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Vietnamese Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'
 
       - name: Crowdin Download Welsh
         uses: crowdin/github-action@v1.13.1
@@ -737,4 +737,4 @@ jobs:
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Welsh Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v4'

--- a/.github/workflows/crowdin-v4-dl-package-translations.yml
+++ b/.github/workflows/crowdin-v4-dl-package-translations.yml
@@ -38,6 +38,7 @@ jobs:
         export_only_approved: true
         # The message of the commit
         commit_message: 'New Afrikaans Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -53,6 +54,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Albanian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -68,6 +70,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Arabic Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -83,6 +86,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Armenian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -98,6 +102,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Azerbaijani Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -113,6 +118,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Basque Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -128,6 +134,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Bengali Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -143,6 +150,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Bosnian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -158,6 +166,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Bulgarian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -173,6 +182,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Catalan Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -188,6 +198,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Chinese Simplified Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -203,6 +214,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Chinese Traditional Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -218,6 +230,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Croatian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -233,6 +246,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Czech Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -248,6 +262,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Danish Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -263,6 +278,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Dari Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -278,6 +294,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Dutch Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -293,6 +310,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Dutch Belgium Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -308,6 +326,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New English Australia Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -323,6 +342,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New English Canada Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -338,6 +358,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New English New Zealand Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -353,6 +374,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New English US Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -368,6 +390,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New English South Africa Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -383,6 +406,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Esperanto Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -398,6 +422,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Estonian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -413,6 +438,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Finnish Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -428,6 +454,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New French Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -443,6 +470,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New French Canada Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -458,6 +486,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Galician Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -473,6 +502,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Georgian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -493,6 +523,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Greek Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -508,6 +539,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Gujarati Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -523,6 +555,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Hebrew Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -538,6 +571,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Hindi Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -553,6 +587,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Hungarian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -568,6 +603,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Indonesian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -583,6 +619,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Irish Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -598,6 +635,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Italian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -614,6 +652,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Kazakh Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -629,6 +668,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Khmer Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -644,6 +684,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Korean Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -659,6 +700,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Kyrgyz Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -674,6 +716,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Lao Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -689,6 +732,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Latvian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -704,6 +748,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Lithuanian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -719,6 +764,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Macedonian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -734,6 +780,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Malay Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -749,6 +796,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Malayalam Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -764,6 +812,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Marathi Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -779,6 +828,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Mongolian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -794,6 +844,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Ndonga Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -809,6 +860,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Northern Sami Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -824,6 +876,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Norwegian Bokmal Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -839,6 +892,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Norwegian Nynorsk Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -854,6 +908,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Occitan Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -869,6 +924,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Pashto Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -884,6 +940,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Persian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -900,6 +957,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Portuguese Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -915,6 +973,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Portuguese Brazilian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -930,6 +989,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Romanian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -946,6 +1006,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Serbian Cyrillic Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -961,6 +1022,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Serbian Latin Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -976,6 +1038,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Sinhala Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -991,6 +1054,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Slovak Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1006,6 +1070,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Slovenian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1022,6 +1087,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Spanish Colombia Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1037,6 +1103,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Spanish Mexico Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1052,6 +1119,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Swahili Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1067,6 +1135,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Swedish Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1082,6 +1151,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Syriac Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1097,6 +1167,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Tagalog Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1112,6 +1183,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Tamil Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1127,6 +1199,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Thai Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1142,6 +1215,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Tornedalen, Finland Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1157,6 +1231,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Turkish Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1172,6 +1247,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Turkmen Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1188,6 +1264,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Urdu India Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1203,6 +1280,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Urdu (Pakistan) Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1218,6 +1296,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Uyghur Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1233,6 +1312,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Vietnamese Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1248,6 +1328,7 @@ jobs:
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Welsh Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v4'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:

--- a/.github/workflows/crowdin-v5-dl-installer-translations.yml
+++ b/.github/workflows/crowdin-v5-dl-installer-translations.yml
@@ -26,13 +26,14 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: af
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Afrikaans Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       #      "LanguageName": "Amharic",
       #      "CrowdinID": "am"
@@ -41,13 +42,14 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: ar
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Arabic Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       #      "LanguageName": "Armenian",
       #      "CrowdinID": "hy"
@@ -59,13 +61,14 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: eu
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Basque Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       #      "LanguageName": "Bengali",
       #      "CrowdinID": "bn"
@@ -77,157 +80,170 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: bg
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Bulgarian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Catalan
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: ca
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Catalan Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Chinese Simplified
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: zh-CN
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Chinese Simplified Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Chinese Traditional
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: zh-TW
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Chinese Traditional Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Croatian
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: hr
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Croatian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Czech
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: cs
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Czech Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Danish
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: da
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Danish Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Dari
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: fa-AF
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Dari Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Dutch
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: nl
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Dutch Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Dutch Belgium
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: nl-BE
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Dutch Belgium Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download English Australia
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: en-AU
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New English Australia Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download English Canada
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: en-CA
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New English Canada Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download English New Zealand
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: en-NZ
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New English New Zealand Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       #      "LanguageName": "English South Africa",
       #      "CrowdinID": "en-ZA"
@@ -236,13 +252,14 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: en-US
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New English US Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       #      "LanguageName": "Esperanto",
       #      "CrowdinID": "eo"
@@ -251,37 +268,40 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: et
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Estonian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Finnish
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: fi
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Finnish Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download French
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: fr
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New French Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       #      "LanguageName": "French, Canada",
       #      "CrowdinID": "fr-CA"
@@ -293,13 +313,14 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: ka
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Georgian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       # German doesn't use Crowdin
       # German Austria doesn't use Crowdin
@@ -311,13 +332,14 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: el
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Greek Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       #      "LanguageName": "Gujarati",
       #      "CrowdinID": "gu"
@@ -326,13 +348,14 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: he
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Hebrew Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       #      "LanguageName": "Hindi",
       #      "CrowdinID": "hi"
@@ -341,25 +364,27 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: hu
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Hungarian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Indonesian
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: id
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Indonesian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       #      "LanguageName": "Irish",
       #      "CrowdinID": "ga"
@@ -368,37 +393,40 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: it
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Italian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Japanese
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: ja
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Japanese Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Kazakh
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: kk
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Kazakh Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       #      "LanguageName": "Khmer",
       #      "CrowdinID": "km"
@@ -416,37 +444,40 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: lv
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Latvian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Lithuanian
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: lt
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Lithuanian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Macedonian
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: mk
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Macedonian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       #      "LanguageName": "Malay",
       #      "CrowdinID": "ms"
@@ -465,13 +496,14 @@ jobs:
       #      uses: crowdin/github-action@v1.13.1
       #      with:
       #        config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
       #        upload_sources: false
       #        download_translations: true
       #        download_language: nb
       #        skip_untranslated_strings: true
       #        export_only_approved: true
       #        commit_message: 'New Norwegian Bokmal Crowdin translations by Github Action'
-      #        localization_branch_name: 'l10n_crowdin_installer'
+      #        localization_branch_name: 'l10n_crowdin_installer_v5'
 
       #      "LanguageName": "Norwegian Nynorsk",
       #      "CrowdinID": "nn-NO"
@@ -486,99 +518,107 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: fa
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Persian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Polish
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: pl
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Polish Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Portuguese
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: pt
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Portuguese Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Portuguese, Brazilian
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: pt-BR
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Portuguese, Brazilian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Romanian
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: ro
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Romanian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       # Russian doesn't use Crowdin
       # - name: Crowdin Download Russian
       #  uses: crowdin/github-action@v1.13.1
       #  with:
       #    config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
       #    upload_sources: false
       #    download_translations: true
       #    download_language: ru
       #    skip_untranslated_strings: true
       #    export_only_approved: true
       #    commit_message: 'New Russian Crowdin translations by Github Action'
-      #    localization_branch_name: 'l10n_crowdin_installer'
+      #    localization_branch_name: 'l10n_crowdin_installer_v5'
 
       # Joomla INI not ready yet
       # - name: Crowdin Download Serbian (Cyrillic)
       #  uses: crowdin/github-action@v1.13.1
       #  with:
       #    config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
       #    upload_sources: false
       #    download_translations: true
       #    download_language: sr-Cyrl
       #    skip_untranslated_strings: true
       #    export_only_approved: true
       #    commit_message: 'New Serbian Cyrillic Crowdin translations by Github Action'
-      #    localization_branch_name: 'l10n_crowdin_installer'
+      #    localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Serbian (Latin)
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: sr-Latn
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Serbian Latin Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       #      "LanguageName": "Sinhala",
       #      "CrowdinID": "si"
@@ -587,37 +627,40 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: sk
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Slovak Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Slovenian
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: sl
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Slovenian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Spanish
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: es
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Spanish Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       #      "LanguageName": "Spanish, Colombia",
       #      "CrowdinID": "es-CO"
@@ -632,13 +675,14 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: sv
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Swedish Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       #      "LanguageName": "Syriac",
       #      "CrowdinID": "syc"
@@ -650,37 +694,40 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: ta
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Tamil Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Thai
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: th
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Thai Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Turkish
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: tr
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Turkish Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       #      "LanguageName": "Turkmen",
       #      "CrowdinID": "tk"
@@ -689,13 +736,14 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: uk
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Ukrainian Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       #      "LanguageName": "Urdu (India)",
       #      "CrowdinID": "ur-IN"
@@ -704,13 +752,14 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: ur
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Urdu (Pakistan) Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       #      "LanguageName": "Uyghur",
       #      "CrowdinID": "ug"
@@ -719,22 +768,24 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: vi
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Vietnamese Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'
 
       - name: Crowdin Download Welsh
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: cy
           skip_untranslated_strings: true
           export_only_approved: true
           commit_message: 'New Welsh Crowdin translations by Github Action'
-          localization_branch_name: 'l10n_crowdin_installer'
+          localization_branch_name: 'l10n_crowdin_installer_v5'

--- a/.github/workflows/crowdin-v5-dl-package-translations.yml
+++ b/.github/workflows/crowdin-v5-dl-package-translations.yml
@@ -25,6 +25,7 @@ jobs:
       with:
         # Option to specify a path to the configuration file, without / at the beginning
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         # Upload sources to Crowdin
         upload_sources: false
         # Make pull request of Crowdin translations
@@ -38,6 +39,7 @@ jobs:
         export_only_approved: true
         # The message of the commit
         commit_message: 'New Afrikaans Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -47,12 +49,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: sq
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Albanian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -62,12 +66,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ar
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Arabic Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -77,12 +83,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: hy
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Armenian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -92,12 +100,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: az
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Azerbaijani Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -107,12 +117,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: eu
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Basque Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -122,12 +134,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: bn
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Bengali Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -137,12 +151,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: bs
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Bosnian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -152,12 +168,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: bg
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Bulgarian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -167,12 +185,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ca
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Catalan Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -182,12 +202,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: zh-CN
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Chinese Simplified Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -197,12 +219,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: zh-TW
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Chinese Traditional Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -212,12 +236,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: hr
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Croatian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -227,12 +253,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: cs
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Czech Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -242,12 +270,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: da
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Danish Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -257,12 +287,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: fa-AF
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Dari Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -272,12 +304,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: nl
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Dutch Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -287,12 +321,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: nl-BE
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Dutch Belgium Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -302,12 +338,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: en-AU
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New English Australia Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -317,12 +355,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: en-CA
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New English Canada Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -332,12 +372,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: en-NZ
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New English New Zealand Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -347,12 +389,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: en-US
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New English US Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -362,12 +406,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: en-ZA
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New English South Africa Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -377,12 +423,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: eo
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Esperanto Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -392,12 +440,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: et
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Estonian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -407,12 +457,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: fi
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Finnish Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -422,12 +474,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: fr
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New French Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -437,12 +491,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: fr-CA
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New French Canada Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -452,12 +508,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: gl
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Galician Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -467,12 +525,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ka
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Georgian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -487,12 +547,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: el
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Greek Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -502,12 +564,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: gu
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Gujarati Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -517,12 +581,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: he
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Hebrew Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -532,12 +598,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: hi
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Hindi Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -547,12 +615,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: hu
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Hungarian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -562,12 +632,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: id
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Indonesian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -577,12 +649,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ga
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Irish Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -592,12 +666,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: it
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Italian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -608,12 +684,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: kk
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Kazakh Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -623,12 +701,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: km
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Khmer Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -638,12 +718,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ko
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Korean Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -653,12 +735,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ky
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Kyrgyz Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -668,12 +752,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: lo
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Lao Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -683,12 +769,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: lv
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Latvian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -698,12 +786,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: lt
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Lithuanian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -713,12 +803,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: mk
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Macedonian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -728,12 +820,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ms
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Malay Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -743,12 +837,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ml
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Malayalam Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -758,12 +854,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: mr
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Marathi Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -773,12 +871,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: mn
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Mongolian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -788,12 +888,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ng
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Ndonga Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -803,12 +905,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: se
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Northern Sami Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -818,12 +922,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: nb
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Norwegian Bokmal Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -833,12 +939,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: nn-NO
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Norwegian Nynorsk Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -848,12 +956,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: oc
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Occitan Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -863,12 +973,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ps
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Pashto Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -878,12 +990,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: fa
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Persian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -894,12 +1008,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: pt
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Portuguese Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -909,12 +1025,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: pt-BR
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Portuguese Brazilian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -924,12 +1042,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ro
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Romanian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -940,12 +1060,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: sr-Cyrl
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Serbian Cyrillic Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -955,12 +1077,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: sr-Latn
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Serbian Latin Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -970,12 +1094,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: si
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Sinhala Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -985,12 +1111,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: sk
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Slovak Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1000,12 +1128,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: sl
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Slovenian Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1016,12 +1146,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: es-CO
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Spanish Colombia Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1031,12 +1163,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: es-MX
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Spanish Mexico Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1046,12 +1180,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: sw
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Swahili Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1061,12 +1197,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: sv
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Swedish Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1076,12 +1214,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: syc
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Syriac Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1091,12 +1231,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: tl
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Tagalog Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1106,12 +1248,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ta
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Tamil Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1121,12 +1265,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: th
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Thai Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1136,12 +1282,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: fit-fi
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Tornedalen, Finland Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1151,12 +1299,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: tr
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Turkish Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1166,12 +1316,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: tk
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Turkmen Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1182,12 +1334,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ur-IN
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Urdu India Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1197,12 +1351,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ur
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Urdu (Pakistan) Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1212,12 +1368,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ug
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Uyghur Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1227,12 +1385,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: vi
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Vietnamese Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:
@@ -1242,12 +1402,14 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: cy
         skip_untranslated_strings: true
         export_only_approved: true
         commit_message: 'New Welsh Crowdin translations by Github Action'
+        localization_branch_name: 'l10n_crowdin_package_v5'
         github_user_name: 'joomla-translation-bot'
         github_user_email: 'release+translation-bot@joomla.org'
       env:

--- a/.github/workflows/local-upload-austrian_v5.yml
+++ b/.github/workflows/local-upload-austrian_v5.yml
@@ -31,6 +31,8 @@ jobs:
         import_eq_suggestions: true
         # Option to specify a path to the configuration file, without / at the beginning
         config: 'Configurations/Crowdin-J5-All.yml'
+        # Upload sources to Crowdin branch
+        crowdin_branch_name: JoomlaV5
         # Use true for dryrun to test the run without actually processing anything
         dryrun_action: false
       env:

--- a/.github/workflows/local-upload-german_v5.yml
+++ b/.github/workflows/local-upload-german_v5.yml
@@ -31,6 +31,8 @@ jobs:
         import_eq_suggestions: true
         # Option to specify a path to the configuration file, without / at the beginning
         config: 'Configurations/Crowdin-J5-All.yml'
+        # Upload sources to Crowdin branch
+        crowdin_branch_name: JoomlaV5
         # Use true for dryrun to test the run without actually processing anything
         dryrun_action: false
       env:

--- a/.github/workflows/local-upload-liechtenstein_v5.yml
+++ b/.github/workflows/local-upload-liechtenstein_v5.yml
@@ -31,6 +31,8 @@ jobs:
         import_eq_suggestions: true
         # Option to specify a path to the configuration file, without / at the beginning
         config: 'Configurations/Crowdin-J5-All.yml'
+        # Upload sources to Crowdin branch
+        crowdin_branch_name: JoomlaV5
         # Use true for dryrun to test the run without actually processing anything
         dryrun_action: false
       env:

--- a/.github/workflows/local-upload-luxembourg_v5.yml
+++ b/.github/workflows/local-upload-luxembourg_v5.yml
@@ -31,6 +31,8 @@ jobs:
         import_eq_suggestions: true
         # Option to specify a path to the configuration file, without / at the beginning
         config: 'Configurations/Crowdin-J5-All.yml'
+        # Upload sources to Crowdin branch
+        crowdin_branch_name: JoomlaV5
         # Use true for dryrun to test the run without actually processing anything
         dryrun_action: false
       env:

--- a/.github/workflows/local-upload-polish_v5.yml
+++ b/.github/workflows/local-upload-polish_v5.yml
@@ -31,6 +31,8 @@ jobs:
         import_eq_suggestions: true
         # Option to specify a path to the configuration file, without / at the beginning
         config: 'Configurations/Crowdin-J5-All.yml'
+        # Upload sources to Crowdin branch
+        crowdin_branch_name: JoomlaV5
         # Use true for dryrun to test the run without actually processing anything
         dryrun_action: false
       env:

--- a/.github/workflows/local-upload-swiss_v5.yml
+++ b/.github/workflows/local-upload-swiss_v5.yml
@@ -31,6 +31,8 @@ jobs:
         import_eq_suggestions: true
         # Option to specify a path to the configuration file, without / at the beginning
         config: 'Configurations/Crowdin-J5-All.yml'
+        # Upload sources to Crowdin branch
+        crowdin_branch_name: JoomlaV5
         # Use true for dryrun to test the run without actually processing anything
         dryrun_action: false
       env:

--- a/.github/workflows/remote-get-japanese.yml
+++ b/.github/workflows/remote-get-japanese.yml
@@ -6,7 +6,7 @@ name: J4 Get Japanese Translation files
 
 on:
   workflow_dispatch:
-  # Runs once a day at 8:01
+  # Runs once a day at 8:31
   schedule:
     - cron:  '31 8 * * *'
 

--- a/.github/workflows/remote-get-spanish.yml
+++ b/.github/workflows/remote-get-spanish.yml
@@ -6,7 +6,7 @@ name: J4 Get Spanish Translation files
 
 on:
   workflow_dispatch:
-  # Runs once a day at 8:01
+  # Runs once a day at 8:16
   schedule:
     - cron:  '16 8 * * *'
 

--- a/.github/workflows/remote-get-ukrainian.yml
+++ b/.github/workflows/remote-get-ukrainian.yml
@@ -6,7 +6,7 @@ name: J4 Get Ukrainian Translation files
 
 on:
   workflow_dispatch:
-  # Runs once a day at 8:01
+  # Runs once a day at 8:46
   schedule:
     - cron:  '46 8 * * *'
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ There are dedicated community members for many translations. They can be found o
 ## Installer files
 
 The installer files (Installer\language\en-GB // joomla.ini and langmetadata.xml) are managed in Crowdin.
-This is required too keep the Core installation process intact.
+This is required to keep the Core installation process intact.
 In the Crowdin platform things are locked and automated to keep everything aligned.
 These two files can't be processed manual, because of the amount of work and risks.
 
@@ -25,10 +25,10 @@ These two files can't be processed manual, because of the amount of work and ris
 * UTC 23:00-00:00 -> Project Build J4
 * UTC 01:01-02:00 -> J4 Download Installer Translations Crowdin Action
 * UTC 02:01-03:00 -> J4 Download Package Translations Crowdin Action
-* UTC 06:12-07:12 -> Get J4 Core Source and Upload too Crowdin
+* UTC 06:12-07:12 -> Get J4 Core Source and Upload to Crowdin
 * UTC 03:30-04:30 -> J5 Download Installer Translations Crowdin Action
 * UTC 04:01-05:00 -> J5 Download Package Translations Crowdin Action
-* UTC 07:12-08:12 -> Get J5 Core Source and Upload too Crowdin
+* UTC 07:12-08:12 -> Get J5 Core Source and Upload to Crowdin
 * UTC 08:01-08:15 -> Get Russian and upload Translations to Crowdin
 * UTC 08:16-08:30 -> Get Spanish and upload Translations to Crowdin
 * UTC 08:31-08:45 -> Get Japanese and upload Translations to Crowdin


### PR DESCRIPTION
### Summary of Changes
- update branch names for PRs
- use crowdin _JoomlaV5_ branch in `crowdin-v5-dl-XXX-translations.yml`
- use crowdin _JoomlaV5_ branch in `local-upload-XXX.yml`

### TODOs
- create new workflows for checks (`en-gb-localise`, `jexec_translations`, `long-arrays-localise`) or update existing ones to support v5
