### PR TITLE
Adapt workflows to support Joomla 5

### DIFF
--- a/.github/workflows/_en-gb-localise.yml
+++ b/.github/workflows/_en-gb-localise.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - l10n_crowdin_package_v4
+      - l10n_crowdin_package_v5
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -18,38 +19,55 @@ jobs:
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
-      - name: Check PR content
+        
+      - name: Check PR content Joomla 4
+        if: ${{ github.event.pull_request.base.ref == 'l10n_crowdin_package_v4'}}
         id: build
         run: |
+          mkdir ${{ github.workspace}}/logs  
           cd ./joomla_v4/translations/package
-          mkdir ./logs
-          grep -rn --include \*.php 'En_GBLocalise' | tee ./logs/en_gblocalise_result
-          cat ./logs/en_gblocalise_result | wc -l | tee ./logs/files_affected
-          awk -F/ '{ print $1 }' ./logs/en_gblocalise_result | sort -u | wc -l | tee ./logs/languagepacks_affected
-          aflp=$(head -n 1 ./logs/languagepacks_affected)
-          affi=$(head -n 1 ./logs/files_affected)
-          echo -n "$aflp" > ./logs/languagepacks_affected
-          echo -n "$affi" > ./logs/files_affected
-          cat ./logs/en_gblocalise_result
+          grep -rn --include \*.php 'En_GBLocalise' | tee ${{ github.workspace}}/logs/en_gblocalise_result
+          cat ${{ github.workspace}}/logs/en_gblocalise_result | wc -l | tee ${{ github.workspace}}/logs/files_affected
+          awk -F/ '{ print $1 }' ${{ github.workspace}}/logs/en_gblocalise_result | sort -u | wc -l | tee ./logs/languagepacks_affected
+          aflp=$(head -n 1 ${{ github.workspace}}/logs/languagepacks_affected)
+          affi=$(head -n 1 ${{ github.workspace}}/logs/files_affected)
+          echo -n "$aflp" > ${{ github.workspace}}/logs/languagepacks_affected
+          echo -n "$affi" > ${{ github.workspace}}/logs/files_affected
+          cat ${{ github.workspace}}/logs/en_gblocalise_result
+
+      - name: Check PR content Joomla 5
+        if: ${{ github.event.pull_request.base.ref == 'l10n_crowdin_package_v5'}}
+        id: build-v5
+        run: |
+              mkdir ${{ github.workspace}}/logs
+              cd ${{ github.workspace}}/joomla_v5/translations/package
+              grep -rn --include \*.php 'En_GBLocalise' | tee ${{ github.workspace}}/logs/en_gblocalise_result
+              cat ${{ github.workspace}}/logs/en_gblocalise_result | wc -l | tee ${{ github.workspace}}/logs/files_affected
+              awk -F/ '{ print $1 }' ${{ github.workspace}}/logs/en_gblocalise_result | sort -u | wc -l | tee ./logs/languagepacks_affected
+              aflp=$(head -n 1 ${{ github.workspace}}/logs/languagepacks_affected)
+              affi=$(head -n 1 ${{ github.workspace}}/logs/files_affected)
+              echo -n "$aflp" > ${{ github.workspace}}/logs/languagepacks_affected
+              echo -n "$affi" > ${{ github.workspace}}/logs/files_affected
+              cat ${{ github.workspace}}/logs/en_gblocalise_result
+    
 
       - name: Save PR number
         if: ${{ always() }}
         run: |
-          cd ./joomla_v4/translations/package
-          echo -n ${{ github.event.pull_request.number }} | tee ./logs/pr_number
-          [ -s ./logs/pr_number ] || gh pr list --limit 1 --repo joomla/core-translations --author app/github-actions --state open --json number --jq .[].number > ./logs/pr_number
-          prnumber=$(head -n 1 ./logs/pr_number)
-          echo -n "$prnumber" > ./logs/pr_number
+          echo -n ${{ github.event.pull_request.number }} | tee ${{ github.workspace}}/logs/pr_number
+          [ -s ./logs/pr_number ] || gh pr list --limit 1 --repo joomla/core-translations --author app/github-actions --state open --json number --jq .[].number > ${{ github.workspace}}/logs/pr_number
+          prnumber=$(head -n 1 ${{ github.workspace}}/logs/pr_number)
+          echo -n "$prnumber" > ${{ github.workspace}}/logs/pr_number
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Save PR sha
         if: ${{ always() }}
-        run: echo ${{ github.sha }} | tee ./joomla_v4/translations/package/logs/pr_sha
+        run: echo ${{ github.sha }} | tee ${{ github.workspace}}/logs/pr_sha
 
       - name: fail workflow
         run: |
-         if [ -s ./joomla_v4/translations/package/logs/en_gblocalise_result ]; then
+         if [ -s ${{ github.workspace}}/logs/en_gblocalise_result ]; then
          exit 1
          fi
 
@@ -58,5 +76,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: En_GBLocalise-logs
-          path: ./joomla_v4/translations/package/logs
+          path: ${{ github.workspace}}/logs
 

--- a/.github/workflows/_jexec_translations.yml
+++ b/.github/workflows/_jexec_translations.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - l10n_crowdin_package_v4
+      - l10n_crowdin_package_v5
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -19,38 +20,55 @@ jobs:
     
       - name: Checkout Source Code
         uses: actions/checkout@v4
-      - name: Check PR content
-        id: build
+      - name: Check PR content Joomla 4
+        if: ${{ github.event.pull_request.base.ref == 'l10n_crowdin_package_v4'}}
+        id: build-v4
         run: |
-          cd ./joomla_v4/translations/package
-          mkdir ./logs
-          grep -Lr --include \*.php '_JEXEC' | tee ./logs/jexec_result
-          cat ./logs/jexec_result | wc -l | tee ./logs/files_affected_jexec
-          awk -F/ '{ print $1 }' ./logs/jexec_result | sort -u | wc -l | tee ./logs/languagepacks_affected_jexec
-          aflp=$(head -n 1 ./logs/languagepacks_affected_jexec)
-          affi=$(head -n 1 ./logs/files_affected_jexec)
-          echo -n "$aflp" > ./logs/languagepacks_affected_jexec
-          echo -n "$affi" > ./logs/files_affected_jexec
-          cat ./logs/jexec_result
+          mkdir ${{ github.workspace}}/logs  
+          cd ${{ github.workspace}}/joomla_v4/translations/package
+          grep -Lr --include \*.php '_JEXEC' | tee ${{ github.workspace}}/logs/jexec_result
+          cat ${{ github.workspace}}/logs/jexec_result | wc -l | tee ${{ github.workspace}}/logs/files_affected_jexec
+          awk -F/ '{ print $1 }' ${{ github.workspace}}/logs/jexec_result | sort -u | wc -l | tee ${{ github.workspace}}/logs/languagepacks_affected_jexec
+          aflp=$(head -n 1 ${{ github.workspace}}/logs/languagepacks_affected_jexec)
+          affi=$(head -n 1 ${{ github.workspace}}/logs/files_affected_jexec)
+          echo -n "$aflp" > ${{ github.workspace}}/logs/languagepacks_affected_jexec
+          echo -n "$affi" > ${{ github.workspace}}/logs/files_affected_jexec
+          cat ${{ github.workspace}}/logs/jexec_result
+
+      - name: Check PR content Joomla 5
+        if: ${{ github.event.pull_request.base.ref == 'l10n_crowdin_package_v5'}}
+        id: build-v5
+        run: |
+            mkdir ${{ github.workspace}}/logs
+            cd ${{ github.workspace}}/joomla_v5/translations/package
+            grep -Lr --include \*.php '_JEXEC' | tee ${{ github.workspace}}/logs/jexec_result
+            cat ${{ github.workspace}}/logs/jexec_result | wc -l | tee ${{ github.workspace}}/logs/files_affected_jexec
+            awk -F/ '{ print $1 }' ${{ github.workspace}}/logs/jexec_result | sort -u | wc -l | tee ${{ github.workspace}}/logs/languagepacks_affected_jexec
+            aflp=$(head -n 1 ${{ github.workspace}}/logs/languagepacks_affected_jexec)
+            affi=$(head -n 1 ${{ github.workspace}}/logs/files_affected_jexec)
+            echo -n "$aflp" > ${{ github.workspace}}/logs/languagepacks_affected_jexec
+            echo -n "$affi" > ${{ github.workspace}}/logs/files_affected_jexec
+            cat ${{ github.workspace}}/logs/jexec_result
+
 
       - name: Save PR number
         if: ${{ always() }}
         run: |
           cd ./joomla_v4/translations/package
-          echo -n ${{ github.event.pull_request.number }} | tee ./logs/pr_number
-          [ -s ./logs/pr_number ] || gh pr list --limit 1 --repo joomla/core-translations --author app/github-actions --state open --json number --jq .[].number > ./logs/pr_number
-          prnumber=$(head -n 1 ./logs/pr_number)
-          echo -n "$prnumber" > ./logs/pr_number
+          echo -n ${{ github.event.pull_request.number }} | tee ${{ github.workspace}}/logs/pr_number
+          [ -s ./logs/pr_number ] || gh pr list --limit 1 --repo joomla/core-translations --author app/github-actions --state open --json number --jq .[].number > ${{ github.workspace}}/logs/pr_number
+          prnumber=$(head -n 1 ${{ github.workspace}}/logs/pr_number)
+          echo -n "$prnumber" > ${{ github.workspace}}/logs/pr_number
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Save PR sha
         if: ${{ always() }}
-        run: echo ${{ github.sha }} | tee ./joomla_v4/translations/package/logs/pr_sha
+        run: echo ${{ github.sha }} | tee ${{ github.workspace}}/logs/pr_sha
 
       - name: fail workflow
         run: |
-          if [ -s ./joomla_v4/translations/package/logs/jexec_result ]; then
+          if [ -s ${{ github.workspace}}/logs/jexec_result ]; then
           exit 1
           fi
 
@@ -59,5 +77,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: JEXEC-logs
-          path: ./joomla_v4/translations/package/logs
+          path: ${{ github.workspace}}/logs
 

--- a/.github/workflows/_long-arrays-localise.yml
+++ b/.github/workflows/_long-arrays-localise.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - l10n_crowdin_package_v4
+      - l10n_crowdin_package_v5
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -18,38 +19,55 @@ jobs:
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v4
-      - name: Check PR content
-        id: build
+      - name: Check PR content Joomla v4
+        if: ${{ github.event.pull_request.base.ref == 'l10n_crowdin_package_v4'}}
+        id: build-v4
         run: |
-          cd ./joomla_v4/translations/package
-          mkdir ./logs
-          grep -rn --include \*.php 'array(' | tee ./logs/long_arrays_result
-          grep -rnl --include \*.php 'array(' | wc -l | tee ./logs/long_arrays_files_affected
-          awk -F/ '{ print $1 }' ./logs/long_arrays_result | sort -u | wc -l | tee ./logs/long_arrays_languagepacks_affected
-          aflp=$(head -n 1 ./logs/long_arrays_languagepacks_affected)
-          affi=$(head -n 1 ./logs/long_arrays_files_affected)
-          echo -n "$aflp" > ./logs/long_arrays_languagepacks_affected
-          echo -n "$affi" > ./logs/long_arrays_files_affected
-          cat ./logs/long_arrays_result
+          mkdir ${{ github.workspace}}/logs
+          cd ${{ github.workspace}}/joomla_v4/translations/package
+          grep -rn --include \*.php 'array(' | tee ${{ github.workspace}}/logs/long_arrays_result
+          grep -rnl --include \*.php 'array(' | wc -l | tee ${{ github.workspace}}/logs/long_arrays_files_affected
+          awk -F/ '{ print $1 }' ${{ github.workspace}}/logs/long_arrays_result | sort -u | wc -l | tee ${{ github.workspace}}/logs/long_arrays_languagepacks_affected
+          aflp=$(head -n 1 ${{ github.workspace}}/logs/long_arrays_languagepacks_affected)
+          affi=$(head -n 1 ${{ github.workspace}}/logs/long_arrays_files_affected)
+          echo -n "$aflp" > ${{ github.workspace}}/logs/long_arrays_languagepacks_affected
+          echo -n "$affi" > ${{ github.workspace}}/logs/long_arrays_files_affected
+          cat ${{ github.workspace}}/logs/long_arrays_result
+
+      - name: Check PR content Joomla v4
+        if: ${{ github.event.pull_request.base.ref == 'l10n_crowdin_package_v4'}}
+        id: build-v5
+        run: |
+            mkdir ${{ github.workspace}}/logs
+            cd ${{ github.workspace}}/joomla_v5/translations/package
+            grep -rn --include \*.php 'array(' | tee ${{ github.workspace}}/logs/long_arrays_result
+            grep -rnl --include \*.php 'array(' | wc -l | tee ${{ github.workspace}}/logs/long_arrays_files_affected
+            awk -F/ '{ print $1 }' ${{ github.workspace}}/logs/long_arrays_result | sort -u | wc -l | tee ${{ github.workspace}}/logs/long_arrays_languagepacks_affected
+            aflp=$(head -n 1 ${{ github.workspace}}/logs/long_arrays_languagepacks_affected)
+            affi=$(head -n 1 ${{ github.workspace}}/logs/long_arrays_files_affected)
+            echo -n "$aflp" > ${{ github.workspace}}/logs/long_arrays_languagepacks_affected
+            echo -n "$affi" > ${{ github.workspace}}/logs/long_arrays_files_affected
+            cat ${{ github.workspace}}/logs/long_arrays_result
+  
 
       - name: Save PR number
         if: ${{ always() }}
         run: |
           cd ./joomla_v4/translations/package
           echo -n ${{ github.event.pull_request.number }} | tee ./logs/pr_number
-          [ -s ./logs/pr_number ] || gh pr list --limit 1 --repo joomla/core-translations --author app/github-actions --state open --json number --jq .[].number > ./logs/pr_number
-          prnumber=$(head -n 1 ./logs/pr_number)
-          echo -n "$prnumber" > ./logs/pr_number
+          [ -s ${{ github.workspace}}/logs/pr_number ] || gh pr list --limit 1 --repo joomla/core-translations --author app/github-actions --state open --json number --jq .[].number > ${{ github.workspace}}/logs/pr_number
+          prnumber=$(head -n 1 ${{ github.workspace}}/logs/pr_number)
+          echo -n "$prnumber" > ${{ github.workspace}}/logs/pr_number
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Save PR sha
         if: ${{ always() }}
-        run: echo ${{ github.sha }} | tee ./joomla_v4/translations/package/logs/pr_sha
+        run: echo ${{ github.sha }} | tee ${{ github.workspace}}/logs/pr_sha
 
       - name: fail workflow
         run: |
-         if [ -s ./joomla_v4/translations/package/logs/long_arrays_result ]; then
+         if [ -s ${{ github.workspace}}/logs/long_arrays_result ]; then
          exit 1
          fi
 
@@ -58,5 +76,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: long-arrays-logs
-          path: ./joomla_v4/translations/package/logs
+          path: ${{ github.workspace}}/logs
 


### PR DESCRIPTION
Addresses TODO  from #738 by

- Moving logs to main repository folder
- Run workflows on both `l10n_crowdin_package_v4` and `l10n_crowdin_package_v5` branches and then running conditional step based on branch name

Test failures on this PR are expected because of moving logs folder.