### PR TITLE
use branch

### DIFF
--- a/.github/workflows/crowdin-v5-dl-installer-translations.yml
+++ b/.github/workflows/crowdin-v5-dl-installer-translations.yml
@@ -26,7 +26,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: af
@@ -42,7 +42,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: ar
@@ -61,7 +61,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: eu
@@ -80,7 +80,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: bg
@@ -93,7 +93,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: ca
@@ -106,7 +106,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: zh-CN
@@ -119,7 +119,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: zh-TW
@@ -132,7 +132,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: hr
@@ -145,7 +145,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: cs
@@ -158,7 +158,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: da
@@ -171,7 +171,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: fa-AF
@@ -184,7 +184,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: nl
@@ -197,7 +197,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: nl-BE
@@ -210,7 +210,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: en-AU
@@ -223,7 +223,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: en-CA
@@ -236,7 +236,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: en-NZ
@@ -252,7 +252,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: en-US
@@ -268,7 +268,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: et
@@ -281,7 +281,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: fi
@@ -294,7 +294,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: fr
@@ -313,7 +313,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: ka
@@ -332,7 +332,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: el
@@ -348,7 +348,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: he
@@ -364,7 +364,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: hu
@@ -377,7 +377,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: id
@@ -393,7 +393,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: it
@@ -406,7 +406,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: ja
@@ -419,7 +419,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: kk
@@ -444,7 +444,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: lv
@@ -457,7 +457,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: lt
@@ -470,7 +470,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: mk
@@ -518,7 +518,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: fa
@@ -531,7 +531,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: pl
@@ -544,7 +544,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: pt
@@ -557,7 +557,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: pt-BR
@@ -570,7 +570,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: ro
@@ -611,7 +611,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: sr-Latn
@@ -627,7 +627,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: sk
@@ -640,7 +640,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: sl
@@ -653,7 +653,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: es
@@ -675,7 +675,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: sv
@@ -694,7 +694,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: ta
@@ -707,7 +707,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: th
@@ -720,7 +720,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: tr
@@ -736,7 +736,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: uk
@@ -752,7 +752,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: ur
@@ -768,7 +768,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: vi
@@ -781,7 +781,7 @@ jobs:
         uses: crowdin/github-action@v1.13.1
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
-          # crowdin_branch_name: JoomlaV5
+          crowdin_branch_name: JoomlaV5
           upload_sources: false
           download_translations: true
           download_language: cy

--- a/.github/workflows/crowdin-v5-dl-package-translations.yml
+++ b/.github/workflows/crowdin-v5-dl-package-translations.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         # Option to specify a path to the configuration file, without / at the beginning
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         # Upload sources to Crowdin
         upload_sources: false
         # Make pull request of Crowdin translations
@@ -49,7 +49,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: sq
@@ -66,7 +66,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ar
@@ -83,7 +83,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: hy
@@ -100,7 +100,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: az
@@ -117,7 +117,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: eu
@@ -134,7 +134,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: bn
@@ -151,7 +151,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: bs
@@ -168,7 +168,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: bg
@@ -185,7 +185,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ca
@@ -202,7 +202,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: zh-CN
@@ -219,7 +219,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: zh-TW
@@ -236,7 +236,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: hr
@@ -253,7 +253,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: cs
@@ -270,7 +270,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: da
@@ -287,7 +287,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: fa-AF
@@ -304,7 +304,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: nl
@@ -321,7 +321,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: nl-BE
@@ -338,7 +338,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: en-AU
@@ -355,7 +355,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: en-CA
@@ -372,7 +372,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: en-NZ
@@ -389,7 +389,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: en-US
@@ -406,7 +406,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: en-ZA
@@ -423,7 +423,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: eo
@@ -440,7 +440,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: et
@@ -457,7 +457,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: fi
@@ -474,7 +474,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: fr
@@ -491,7 +491,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: fr-CA
@@ -508,7 +508,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: gl
@@ -525,7 +525,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ka
@@ -547,7 +547,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: el
@@ -564,7 +564,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: gu
@@ -581,7 +581,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: he
@@ -598,7 +598,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: hi
@@ -615,7 +615,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: hu
@@ -632,7 +632,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: id
@@ -649,7 +649,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ga
@@ -666,7 +666,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: it
@@ -684,7 +684,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: kk
@@ -701,7 +701,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: km
@@ -718,7 +718,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ko
@@ -735,7 +735,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ky
@@ -752,7 +752,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: lo
@@ -769,7 +769,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: lv
@@ -786,7 +786,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: lt
@@ -803,7 +803,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: mk
@@ -820,7 +820,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ms
@@ -837,7 +837,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: ml
@@ -854,7 +854,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: mr
@@ -871,7 +871,7 @@ jobs:
       uses: crowdin/github-action@v1.13.1
       with:
         config: 'Configurations/Crowdin-J5-All.yml'
-        # crowdin_branch_name: JoomlaV5
+        crowdin_branch_name: JoomlaV5
         upload_sources: false
         download_translations: true
         download_language: mn


### PR DESCRIPTION
@tecpromotion I think to uncomment all branches #744 was wrong, because we still have not installer translation for j5.
https://github.com/joomla/core-translations/actions/runs/6428697139/job/17456334796

The problem was only in this (+2 other) sections - not in all steps
![image](https://github.com/joomla/core-translations/assets/66922325/23c02017-03b0-440a-aef0-cf8d203b107a)
