### PR TITLE
fix crowdin configuration for v5 and v6 installer

### DIFF
--- a/Configurations/Crowdin-J5-Installer.yml
+++ b/Configurations/Crowdin-J5-Installer.yml
@@ -13,6 +13,12 @@ files:
     translation: /joomla_v5/translations/core/installation/language/%locale%/joomla.ini
     update_option: update_as_unapproved
     type: joomla
+    
+    source: /joomla_v5/source/installation/language/en-GB/joomla.cli.ini
+    dest: 'Installer/language/en-GB/joomla.cli.ini'
+    translation: /joomla_v5/translations/core/installation/language/%locale%/joomla.cli.ini
+    update_option: update_as_unapproved
+    type: joomla
 
   - source: /joomla_v5/source/installation/language/en-GB/langmetadata.xml
     dest: 'Installer/language/en-GB/langmetadata.xml'

--- a/Configurations/Crowdin-J6-Installer.yml
+++ b/Configurations/Crowdin-J6-Installer.yml
@@ -13,6 +13,12 @@ files:
     translation: /joomla_v6/translations/core/installation/language/%locale%/joomla.ini
     update_option: update_as_unapproved
     type: joomla
+    
+    source: /joomla_v6/source/installation/language/en-GB/joomla.cli.ini
+    dest: 'Installer/language/en-GB/joomla.cli.ini'
+    translation: /joomla_v6/translations/core/installation/language/%locale%/joomla.cli.ini
+    update_option: update_as_unapproved
+    type: joomla
 
   - source: /joomla_v6/source/installation/language/en-GB/langmetadata.xml
     dest: 'Installer/language/en-GB/langmetadata.xml'


### PR DESCRIPTION
`/joomla_v6/source/installation/language/en-GB/joomla.cli.ini` and `/joomla_v5/source/installation/language/en-GB/joomla.cli.ini` was not added in configuration files