### PR TITLE
Fix Crowdin installer config: joomla.ini was never downloaded

### DIFF
--- a/Configurations/Crowdin-J5-Installer.yml
+++ b/Configurations/Crowdin-J5-Installer.yml
@@ -13,8 +13,8 @@ files:
     translation: /joomla_v5/translations/core/installation/language/%locale%/joomla.ini
     update_option: update_as_unapproved
     type: joomla
-    
-    source: /joomla_v5/source/installation/language/en-GB/joomla.cli.ini
+
+  - source: /joomla_v5/source/installation/language/en-GB/joomla.cli.ini
     dest: 'Installer/language/en-GB/joomla.cli.ini'
     translation: /joomla_v5/translations/core/installation/language/%locale%/joomla.cli.ini
     update_option: update_as_unapproved

--- a/Configurations/Crowdin-J6-Installer.yml
+++ b/Configurations/Crowdin-J6-Installer.yml
@@ -13,8 +13,8 @@ files:
     translation: /joomla_v6/translations/core/installation/language/%locale%/joomla.ini
     update_option: update_as_unapproved
     type: joomla
-    
-    source: /joomla_v6/source/installation/language/en-GB/joomla.cli.ini
+
+  - source: /joomla_v6/source/installation/language/en-GB/joomla.cli.ini
     dest: 'Installer/language/en-GB/joomla.cli.ini'
     translation: /joomla_v6/translations/core/installation/language/%locale%/joomla.cli.ini
     update_option: update_as_unapproved


### PR DESCRIPTION
## Problem

In `Configurations/Crowdin-J{5,6}-Installer.yml` the `joomla.cli.ini` block is **not a separate YAML list item** — it lacks the leading `- ` and is indented into the preceding entry:

```yaml
  - source: /joomla_v5/source/installation/language/en-GB/joomla.ini
    dest: 'Installer/language/en-GB/joomla.ini'
    translation: /joomla_v5/translations/core/installation/language/%locale%/joomla.ini
    update_option: update_as_unapproved
    type: joomla
                                                    # <-- missing "- "
    source: /joomla_v5/source/installation/language/en-GB/joomla.cli.ini
    dest: 'Installer/language/en-GB/joomla.cli.ini'
    translation: /joomla_v5/translations/core/installation/language/%locale%/joomla.cli.ini
    update_option: update_as_unapproved
    type: joomla
```

Both sets of `source` / `dest` / `translation` keys therefore live in the **same mapping**, so the later values win. Crowdin only ever sees `joomla.cli.ini` (plus `langmetadata.xml`) — **`joomla.ini` is never downloaded for the installer, for any language.**

Introduced in ae98fa951a ("fix crowdin configuration for v5 and v6 installer", 16 Oct 2025).

## Evidence

```
$ git log --since=2025-10-16 --grep='Crowdin translations by Github Action' \
    -- 'joomla_v{5,6}/translations/core/installation/language/*/joomla.ini'
(no commits)

$ git log --since=2025-10-16 --grep='Crowdin translations by Github Action' \
    -- 'joomla_v5/translations/core/installation/language/*/joomla.cli.ini' | wc -l
94
```

Sample commit — only two of the three files land:

```
83b7437088 New Irish Crowdin translations by Github Action
 .../core/installation/language/ga-IE/joomla.cli.ini   |  4 ++++
 .../core/installation/language/ga-IE/langmetadata.xml | 19 +++++++++++++++++++
```

The issue stayed invisible because every other language still carries a `joomla.ini` from before the regression. It surfaced with Irish (`ga-IE`) and Norwegian Bokmal (`nb-NO`), the languages added *after* Oct 2025 — they have no installer `joomla.ini` at all, even though the translations are complete and approved on Crowdin. Both are correctly listed in the download workflow matrices and in `crowdinMapping.json`, so the language configuration itself is fine.

## Fix

Make the `joomla.cli.ini` entry its own list item. Whitespace/indentation only, no semantic changes to any option.

## Heads-up for reviewers

The next scheduled run of *Download Installer Translations J5/J6* will re-sync `joomla.ini` for **all** languages after ~10 months without updates. Expect a correspondingly large first commit on `l10n_crowdin_installer_v5` / `l10n_crowdin_installer_v6`. That is the intended catch-up, not a side effect of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)