### PR TITLE
Pin all GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/_check-php-code.yml
+++ b/.github/workflows/_check-php-code.yml
@@ -20,11 +20,11 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Check PHP syntax errors
-        uses: StephaneBour/actions-php-lint@8.4
+        uses: StephaneBour/actions-php-lint@e81e93ef8d421a09e434b715766a89679dd974dc # 8.4
         with:
           dir: '.'

--- a/.github/workflows/_check-php-code.yml
+++ b/.github/workflows/_check-php-code.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/_en-gb-localise-v5.yml
+++ b/.github/workflows/_en-gb-localise-v5.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check PR content Joomla 5
         id: build-v5

--- a/.github/workflows/_en-gb-localise-v5.yml
+++ b/.github/workflows/_en-gb-localise-v5.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Check PR content Joomla 5
         id: build-v5
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload En_GBLocalise-logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: En_GBLocalise-logs
           path: ${{ github.workspace}}/logs

--- a/.github/workflows/_en-gb-localise-v6.yml
+++ b/.github/workflows/_en-gb-localise-v6.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Check PR content Joomla 6
         id: build-v6
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload En_GBLocalise-logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: En_GBLocalise-logs
           path: ${{ github.workspace}}/logs

--- a/.github/workflows/_en-gb-localise-v6.yml
+++ b/.github/workflows/_en-gb-localise-v6.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check PR content Joomla 6
         id: build-v6

--- a/.github/workflows/_jexec_translations-v5.yml
+++ b/.github/workflows/_jexec_translations-v5.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     
       - name: Checkout Source Code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check PR content Joomla 5
         id: build-v5

--- a/.github/workflows/_jexec_translations-v5.yml
+++ b/.github/workflows/_jexec_translations-v5.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Check PR content Joomla 5
         id: build-v5
@@ -59,7 +59,7 @@ jobs:
 
       - name: JEXEC-logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: JEXEC-logs
           path: ${{ github.workspace}}/logs

--- a/.github/workflows/_jexec_translations-v6.yml
+++ b/.github/workflows/_jexec_translations-v6.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     
       - name: Checkout Source Code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check PR content Joomla 6
         id: build-v6

--- a/.github/workflows/_jexec_translations-v6.yml
+++ b/.github/workflows/_jexec_translations-v6.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Check PR content Joomla 6
         id: build-v6
@@ -59,7 +59,7 @@ jobs:
 
       - name: JEXEC-logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: JEXEC-logs
           path: ${{ github.workspace}}/logs

--- a/.github/workflows/_long-arrays-localise-v5.yml
+++ b/.github/workflows/_long-arrays-localise-v5.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check PR content Joomla v5
         id: build-v5

--- a/.github/workflows/_long-arrays-localise-v5.yml
+++ b/.github/workflows/_long-arrays-localise-v5.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Check PR content Joomla v5
         id: build-v5
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload long-arrays-logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: long-arrays-logs
           path: ${{ github.workspace}}/logs

--- a/.github/workflows/_long-arrays-localise-v6.yml
+++ b/.github/workflows/_long-arrays-localise-v6.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Check PR content Joomla v6
         id: build-v6
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload long-arrays-logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: long-arrays-logs
           path: ${{ github.workspace}}/logs

--- a/.github/workflows/_long-arrays-localise-v6.yml
+++ b/.github/workflows/_long-arrays-localise-v6.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check PR content Joomla v6
         id: build-v6

--- a/.github/workflows/_pr-commen_long_arrays.yml
+++ b/.github/workflows/_pr-commen_long_arrays.yml
@@ -17,11 +17,11 @@ jobs:
     steps:
       - name: on artifact
         id: artifact
-        uses: marocchino/on_artifact@v2
+        uses: marocchino/on_artifact@15ee6e49e31cdbc538ee54332436e6de32c809a3 # v2.0.0
         with:
           name: long-arrays-logs
 
-      - uses: marocchino/sticky-pull-request-comment@v3
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           header: long-arrays ${{ steps.artifact.outputs.pr_number }}  ${{ steps.artifact.outputs.jversion }}

--- a/.github/workflows/_pr-comment.yml
+++ b/.github/workflows/_pr-comment.yml
@@ -17,11 +17,11 @@ jobs:
     steps:
       - name: on artifact
         id: artifact
-        uses: marocchino/on_artifact@v2
+        uses: marocchino/on_artifact@15ee6e49e31cdbc538ee54332436e6de32c809a3 # v2.0.0
         with:
           name: En_GBLocalise-logs
 
-      - uses: marocchino/sticky-pull-request-comment@v3
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           header: En_GBLocalise-class ${{ steps.artifact.outputs.pr_number }}  ${{ steps.artifact.outputs.jversion }}

--- a/.github/workflows/_pr-comment_jexec.yml
+++ b/.github/workflows/_pr-comment_jexec.yml
@@ -17,11 +17,11 @@ jobs:
     steps:
       - name: on artifact
         id: artifact
-        uses: marocchino/on_artifact@v2
+        uses: marocchino/on_artifact@15ee6e49e31cdbc538ee54332436e6de32c809a3 # v2.0.0
         with:
           name: JEXEC-logs
 
-      - uses: marocchino/sticky-pull-request-comment@v3
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           header: JEXEC ${{ steps.artifact.outputs.pr_number }} ${{ steps.artifact.outputs.jversion }}

--- a/.github/workflows/core-get-language-source-v5.yml
+++ b/.github/workflows/core-get-language-source-v5.yml
@@ -18,7 +18,7 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'joomla/core-translations') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Fetch and extract core j5 cms
         run: |
           cd ..
@@ -78,11 +78,11 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
       - name: crowdin action package files
-        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+        uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
         with:
           # Upload sources to Crowdin
           upload_sources: true
@@ -94,7 +94,7 @@ jobs:
           dryrun_action: false
 
       - name: crowdin action installer files
-        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+        uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
         with:
           # Upload sources to Crowdin
           upload_sources: true

--- a/.github/workflows/core-get-language-source-v5.yml
+++ b/.github/workflows/core-get-language-source-v5.yml
@@ -18,7 +18,7 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'joomla/core-translations') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Fetch and extract core j5 cms
         run: |
           cd ..
@@ -78,11 +78,11 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
       - name: crowdin action package files
-        uses: crowdin/github-action@v2.15.2
+        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
         with:
           # Upload sources to Crowdin
           upload_sources: true
@@ -94,7 +94,7 @@ jobs:
           dryrun_action: false
 
       - name: crowdin action installer files
-        uses: crowdin/github-action@v2.15.2
+        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
         with:
           # Upload sources to Crowdin
           upload_sources: true

--- a/.github/workflows/core-get-language-source-v5.yml
+++ b/.github/workflows/core-get-language-source-v5.yml
@@ -82,7 +82,7 @@ jobs:
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
       - name: crowdin action package files
-        uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
         with:
           # Upload sources to Crowdin
           upload_sources: true
@@ -94,7 +94,7 @@ jobs:
           dryrun_action: false
 
       - name: crowdin action installer files
-        uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
         with:
           # Upload sources to Crowdin
           upload_sources: true

--- a/.github/workflows/core-get-language-source-v6.yml
+++ b/.github/workflows/core-get-language-source-v6.yml
@@ -18,7 +18,7 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'joomla/core-translations') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Fetch and extract core j6 cms
         run: |
           cd ..
@@ -78,11 +78,11 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
       - name: crowdin action package files
-        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+        uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
         with:
           # Upload sources to Crowdin
           upload_sources: true
@@ -94,7 +94,7 @@ jobs:
           dryrun_action: false
 
       - name: crowdin action installer files
-        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+        uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
         with:
           # Upload sources to Crowdin
           upload_sources: true

--- a/.github/workflows/core-get-language-source-v6.yml
+++ b/.github/workflows/core-get-language-source-v6.yml
@@ -18,7 +18,7 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'joomla/core-translations') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Fetch and extract core j6 cms
         run: |
           cd ..
@@ -78,11 +78,11 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
       - name: crowdin action package files
-        uses: crowdin/github-action@v2.15.2
+        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
         with:
           # Upload sources to Crowdin
           upload_sources: true
@@ -94,7 +94,7 @@ jobs:
           dryrun_action: false
 
       - name: crowdin action installer files
-        uses: crowdin/github-action@v2.15.2
+        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
         with:
           # Upload sources to Crowdin
           upload_sources: true

--- a/.github/workflows/core-get-language-source-v6.yml
+++ b/.github/workflows/core-get-language-source-v6.yml
@@ -82,7 +82,7 @@ jobs:
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
       - name: crowdin action package files
-        uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
         with:
           # Upload sources to Crowdin
           upload_sources: true
@@ -94,7 +94,7 @@ jobs:
           dryrun_action: false
 
       - name: crowdin action installer files
-        uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
         with:
           # Upload sources to Crowdin
           upload_sources: true

--- a/.github/workflows/crowdin-v5-buildproject.yml
+++ b/.github/workflows/crowdin-v5-buildproject.yml
@@ -16,7 +16,7 @@ jobs:
     # Runs the HTTP Request action command - https://github.com/fjogeleit/http-request-action
     - name: Call build URL
       id: BuildV5CMS
-      uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
+      uses: fjogeleit/http-request-action@f98bb26551cd1af7d3eb2674578a80754ece88db # v2.0.1
       with:
         url: 'https://joomla.crowdin.com/api/v2/projects/${{ secrets.CROWDIN_PROJECT_ID }}/translations/builds'
         method: 'POST'

--- a/.github/workflows/crowdin-v5-buildproject.yml
+++ b/.github/workflows/crowdin-v5-buildproject.yml
@@ -16,7 +16,7 @@ jobs:
     # Runs the HTTP Request action command - https://github.com/fjogeleit/http-request-action
     - name: Call build URL
       id: BuildV5CMS
-      uses: fjogeleit/http-request-action@v2.0.0
+      uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
       with:
         url: 'https://joomla.crowdin.com/api/v2/projects/${{ secrets.CROWDIN_PROJECT_ID }}/translations/builds'
         method: 'POST'

--- a/.github/workflows/crowdin-v5-dl-installer-translations.yml
+++ b/.github/workflows/crowdin-v5-dl-installer-translations.yml
@@ -127,11 +127,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
 
       - name: Crowdin Download ${{ matrix.name }}
-        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+        uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
           crowdin_branch_name: JoomlaV5

--- a/.github/workflows/crowdin-v5-dl-installer-translations.yml
+++ b/.github/workflows/crowdin-v5-dl-installer-translations.yml
@@ -131,7 +131,7 @@ jobs:
 
 
       - name: Crowdin Download ${{ matrix.name }}
-        uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
           crowdin_branch_name: JoomlaV5

--- a/.github/workflows/crowdin-v5-dl-installer-translations.yml
+++ b/.github/workflows/crowdin-v5-dl-installer-translations.yml
@@ -127,11 +127,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
 
       - name: Crowdin Download ${{ matrix.name }}
-        uses: crowdin/github-action@v2.15.2
+        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
         with:
           config: 'Configurations/Crowdin-J5-Installer.yml'
           crowdin_branch_name: JoomlaV5

--- a/.github/workflows/crowdin-v5-dl-package-translations.yml
+++ b/.github/workflows/crowdin-v5-dl-package-translations.yml
@@ -198,7 +198,7 @@ jobs:
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
       - name: Crowdin Download ${{ matrix.name }}
-        uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
         with:
           # Option to specify a path to the configuration file, without / at the beginning
           config: 'Configurations/Crowdin-J5-All.yml'

--- a/.github/workflows/crowdin-v5-dl-package-translations.yml
+++ b/.github/workflows/crowdin-v5-dl-package-translations.yml
@@ -192,13 +192,13 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           token: ${{ secrets.GHA_TRANSLATIONBOT_PAT }}
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
       - name: Crowdin Download ${{ matrix.name }}
-        uses: crowdin/github-action@v2.15.2
+        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
         with:
           # Option to specify a path to the configuration file, without / at the beginning
           config: 'Configurations/Crowdin-J5-All.yml'

--- a/.github/workflows/crowdin-v5-dl-package-translations.yml
+++ b/.github/workflows/crowdin-v5-dl-package-translations.yml
@@ -192,13 +192,13 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.GHA_TRANSLATIONBOT_PAT }}
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
       - name: Crowdin Download ${{ matrix.name }}
-        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+        uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
         with:
           # Option to specify a path to the configuration file, without / at the beginning
           config: 'Configurations/Crowdin-J5-All.yml'

--- a/.github/workflows/crowdin-v6-buildproject.yml
+++ b/.github/workflows/crowdin-v6-buildproject.yml
@@ -16,7 +16,7 @@ jobs:
     # Runs the HTTP Request action command - https://github.com/fjogeleit/http-request-action
     - name: Call build URL
       id: BuildV6CMS
-      uses: fjogeleit/http-request-action@v2.0.0
+      uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
       with:
         url: 'https://joomla.crowdin.com/api/v2/projects/${{ secrets.CROWDIN_PROJECT_ID }}/translations/builds'
         method: 'POST'

--- a/.github/workflows/crowdin-v6-buildproject.yml
+++ b/.github/workflows/crowdin-v6-buildproject.yml
@@ -16,7 +16,7 @@ jobs:
     # Runs the HTTP Request action command - https://github.com/fjogeleit/http-request-action
     - name: Call build URL
       id: BuildV6CMS
-      uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
+      uses: fjogeleit/http-request-action@f98bb26551cd1af7d3eb2674578a80754ece88db # v2.0.1
       with:
         url: 'https://joomla.crowdin.com/api/v2/projects/${{ secrets.CROWDIN_PROJECT_ID }}/translations/builds'
         method: 'POST'

--- a/.github/workflows/crowdin-v6-dl-installer-translations.yml
+++ b/.github/workflows/crowdin-v6-dl-installer-translations.yml
@@ -140,9 +140,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Crowdin Download
-        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+        uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
         with:
           config: 'Configurations/Crowdin-J6-Installer.yml'
           crowdin_branch_name: JoomlaV6

--- a/.github/workflows/crowdin-v6-dl-installer-translations.yml
+++ b/.github/workflows/crowdin-v6-dl-installer-translations.yml
@@ -142,7 +142,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Crowdin Download
-        uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
         with:
           config: 'Configurations/Crowdin-J6-Installer.yml'
           crowdin_branch_name: JoomlaV6

--- a/.github/workflows/crowdin-v6-dl-installer-translations.yml
+++ b/.github/workflows/crowdin-v6-dl-installer-translations.yml
@@ -140,9 +140,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Crowdin Download
-        uses: crowdin/github-action@v2.15.2
+        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
         with:
           config: 'Configurations/Crowdin-J6-Installer.yml'
           crowdin_branch_name: JoomlaV6

--- a/.github/workflows/crowdin-v6-dl-package-translations.yml
+++ b/.github/workflows/crowdin-v6-dl-package-translations.yml
@@ -201,12 +201,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.GHA_TRANSLATIONBOT_PAT }}
 
       - name: Crowdin Download ${{ matrix.name }}
-        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+        uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
         with:
           config: 'Configurations/Crowdin-J6-All.yml'
           crowdin_branch_name: JoomlaV6

--- a/.github/workflows/crowdin-v6-dl-package-translations.yml
+++ b/.github/workflows/crowdin-v6-dl-package-translations.yml
@@ -206,7 +206,7 @@ jobs:
           token: ${{ secrets.GHA_TRANSLATIONBOT_PAT }}
 
       - name: Crowdin Download ${{ matrix.name }}
-        uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
         with:
           config: 'Configurations/Crowdin-J6-All.yml'
           crowdin_branch_name: JoomlaV6

--- a/.github/workflows/crowdin-v6-dl-package-translations.yml
+++ b/.github/workflows/crowdin-v6-dl-package-translations.yml
@@ -201,12 +201,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           token: ${{ secrets.GHA_TRANSLATIONBOT_PAT }}
 
       - name: Crowdin Download ${{ matrix.name }}
-        uses: crowdin/github-action@v2.15.2
+        uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
         with:
           config: 'Configurations/Crowdin-J6-All.yml'
           crowdin_branch_name: JoomlaV6

--- a/.github/workflows/local-upload-german-all_v5.yml
+++ b/.github/workflows/local-upload-german-all_v5.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Crowdin Upload ${{ matrix.name }}
-      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         upload_sources: false
         upload_translations: true

--- a/.github/workflows/local-upload-german-all_v5.yml
+++ b/.github/workflows/local-upload-german-all_v5.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Crowdin Upload ${{ matrix.name }}
-      uses: crowdin/github-action@v2.15.2
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         upload_sources: false
         upload_translations: true

--- a/.github/workflows/local-upload-german-all_v5.yml
+++ b/.github/workflows/local-upload-german-all_v5.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Crowdin Upload ${{ matrix.name }}
-      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
       with:
         upload_sources: false
         upload_translations: true

--- a/.github/workflows/local-upload-german-all_v6.yml
+++ b/.github/workflows/local-upload-german-all_v6.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Crowdin Upload ${{ matrix.name }}
-      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         upload_sources: false
         upload_translations: true

--- a/.github/workflows/local-upload-german-all_v6.yml
+++ b/.github/workflows/local-upload-german-all_v6.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     - name: Crowdin Upload ${{ matrix.name }}
-      uses: crowdin/github-action@v2.15.2
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         upload_sources: false
         upload_translations: true

--- a/.github/workflows/local-upload-german-all_v6.yml
+++ b/.github/workflows/local-upload-german-all_v6.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Crowdin Upload ${{ matrix.name }}
-      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
       with:
         upload_sources: false
         upload_translations: true

--- a/.github/workflows/local-upload-polish_v5.yml
+++ b/.github/workflows/local-upload-polish_v5.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Polish
-      uses: crowdin/github-action@v2.15.2
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false
@@ -42,7 +42,7 @@ jobs:
 
      # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Polish installer
-      uses: crowdin/github-action@v2.15.2
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/local-upload-polish_v5.yml
+++ b/.github/workflows/local-upload-polish_v5.yml
@@ -17,7 +17,7 @@ jobs:
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Polish
-      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false
@@ -42,7 +42,7 @@ jobs:
 
      # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Polish installer
-      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/local-upload-polish_v5.yml
+++ b/.github/workflows/local-upload-polish_v5.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Polish
-      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
       with:
         # Upload sources to Crowdin
         upload_sources: false
@@ -42,7 +42,7 @@ jobs:
 
      # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Polish installer
-      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/local-upload-polish_v6.yml
+++ b/.github/workflows/local-upload-polish_v6.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Polish
-      uses: crowdin/github-action@v2.15.2
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false
@@ -42,7 +42,7 @@ jobs:
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Polish installer
-      uses: crowdin/github-action@v2.15.2
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/local-upload-polish_v6.yml
+++ b/.github/workflows/local-upload-polish_v6.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Polish
-      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
       with:
         # Upload sources to Crowdin
         upload_sources: false
@@ -42,7 +42,7 @@ jobs:
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Polish installer
-      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/local-upload-polish_v6.yml
+++ b/.github/workflows/local-upload-polish_v6.yml
@@ -17,7 +17,7 @@ jobs:
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Polish
-      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false
@@ -42,7 +42,7 @@ jobs:
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Polish installer
-      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-japanese-v5.yml
+++ b/.github/workflows/remote-get-japanese-v5.yml
@@ -87,7 +87,7 @@ jobs:
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Japanese
-      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-japanese-v5.yml
+++ b/.github/workflows/remote-get-japanese-v5.yml
@@ -15,7 +15,7 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'joomla/core-translations') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Fetch and extract Japanese j5 cms
         run: |
           cd ..
@@ -83,11 +83,11 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Japanese
-      uses: crowdin/github-action@v2.15.2
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-japanese-v5.yml
+++ b/.github/workflows/remote-get-japanese-v5.yml
@@ -15,7 +15,7 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'joomla/core-translations') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Fetch and extract Japanese j5 cms
         run: |
           cd ..
@@ -83,11 +83,11 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Japanese
-      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-malay-v5.yml
+++ b/.github/workflows/remote-get-malay-v5.yml
@@ -15,7 +15,7 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'joomla/core-translations') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Fetch and extract Malay J5 cms
         run: |
           cd ..
@@ -90,11 +90,11 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Malay
-      uses: crowdin/github-action@v2.15.2
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false
@@ -119,7 +119,7 @@ jobs:
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Malay Installer
-      uses: crowdin/github-action@v2.15.2
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-malay-v5.yml
+++ b/.github/workflows/remote-get-malay-v5.yml
@@ -15,7 +15,7 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'joomla/core-translations') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Fetch and extract Malay J5 cms
         run: |
           cd ..
@@ -90,11 +90,11 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Malay
-      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
       with:
         # Upload sources to Crowdin
         upload_sources: false
@@ -119,7 +119,7 @@ jobs:
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Malay Installer
-      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-malay-v5.yml
+++ b/.github/workflows/remote-get-malay-v5.yml
@@ -94,7 +94,7 @@ jobs:
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Malay
-      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false
@@ -119,7 +119,7 @@ jobs:
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Malay Installer
-      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-malay-v6.yml
+++ b/.github/workflows/remote-get-malay-v6.yml
@@ -15,7 +15,7 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'joomla/core-translations') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Fetch and extract Malay j6 cms
         run: |
           cd ..
@@ -90,11 +90,11 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Malay
-      uses: crowdin/github-action@v2.15.2
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false
@@ -119,7 +119,7 @@ jobs:
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Malay Installer
-      uses: crowdin/github-action@v2.15.2
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-malay-v6.yml
+++ b/.github/workflows/remote-get-malay-v6.yml
@@ -94,7 +94,7 @@ jobs:
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Malay
-      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false
@@ -119,7 +119,7 @@ jobs:
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Malay Installer
-      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-malay-v6.yml
+++ b/.github/workflows/remote-get-malay-v6.yml
@@ -15,7 +15,7 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'joomla/core-translations') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Fetch and extract Malay j6 cms
         run: |
           cd ..
@@ -90,11 +90,11 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Malay
-      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
       with:
         # Upload sources to Crowdin
         upload_sources: false
@@ -119,7 +119,7 @@ jobs:
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Malay Installer
-      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-russian-v5.yml
+++ b/.github/workflows/remote-get-russian-v5.yml
@@ -94,7 +94,7 @@ jobs:
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Russian
-      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false
@@ -119,7 +119,7 @@ jobs:
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Russian Installer
-      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-russian-v5.yml
+++ b/.github/workflows/remote-get-russian-v5.yml
@@ -15,7 +15,7 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'joomla/core-translations') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Fetch and extract Russian j5 cms
         run: |
           cd ..
@@ -90,11 +90,11 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Russian
-      uses: crowdin/github-action@v2.15.2
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false
@@ -119,7 +119,7 @@ jobs:
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Russian Installer
-      uses: crowdin/github-action@v2.15.2
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-russian-v5.yml
+++ b/.github/workflows/remote-get-russian-v5.yml
@@ -15,7 +15,7 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'joomla/core-translations') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Fetch and extract Russian j5 cms
         run: |
           cd ..
@@ -90,11 +90,11 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Russian
-      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
       with:
         # Upload sources to Crowdin
         upload_sources: false
@@ -119,7 +119,7 @@ jobs:
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Russian Installer
-      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-russian-v6.yml
+++ b/.github/workflows/remote-get-russian-v6.yml
@@ -15,7 +15,7 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'joomla/core-translations') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Fetch and extract Russian j6 cms
         run: |
           cd ..
@@ -90,11 +90,11 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Russian
-      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
       with:
         # Upload sources to Crowdin
         upload_sources: false
@@ -119,7 +119,7 @@ jobs:
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Russian Installer
-      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-russian-v6.yml
+++ b/.github/workflows/remote-get-russian-v6.yml
@@ -94,7 +94,7 @@ jobs:
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Russian
-      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false
@@ -119,7 +119,7 @@ jobs:
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Russian Installer
-      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-russian-v6.yml
+++ b/.github/workflows/remote-get-russian-v6.yml
@@ -15,7 +15,7 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'joomla/core-translations') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Fetch and extract Russian j6 cms
         run: |
           cd ..
@@ -90,11 +90,11 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Russian
-      uses: crowdin/github-action@v2.15.2
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false
@@ -119,7 +119,7 @@ jobs:
 
       # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Russian Installer
-      uses: crowdin/github-action@v2.15.2
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-ukrainian-v5.yml
+++ b/.github/workflows/remote-get-ukrainian-v5.yml
@@ -15,7 +15,7 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'joomla/core-translations') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Fetch and extract Ukrainian j5 cms
         run: |
           cd ..
@@ -83,11 +83,11 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Ukrainian
-      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-ukrainian-v5.yml
+++ b/.github/workflows/remote-get-ukrainian-v5.yml
@@ -87,7 +87,7 @@ jobs:
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Ukrainian
-      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-ukrainian-v5.yml
+++ b/.github/workflows/remote-get-ukrainian-v5.yml
@@ -15,7 +15,7 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'joomla/core-translations') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Fetch and extract Ukrainian j5 cms
         run: |
           cd ..
@@ -83,11 +83,11 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Ukrainian
-      uses: crowdin/github-action@v2.15.2
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-ukrainian-v6.yml
+++ b/.github/workflows/remote-get-ukrainian-v6.yml
@@ -15,7 +15,7 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'joomla/core-translations') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: Fetch and extract Ukrainian j6 cms
         run: |
           cd ..
@@ -83,11 +83,11 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Ukrainian
-      uses: crowdin/github-action@v2.15.2
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-ukrainian-v6.yml
+++ b/.github/workflows/remote-get-ukrainian-v6.yml
@@ -15,7 +15,7 @@ jobs:
     if: (github.event_name == 'schedule' && github.repository == 'joomla/core-translations') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Fetch and extract Ukrainian j6 cms
         run: |
           cd ..
@@ -83,11 +83,11 @@ jobs:
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout
-      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Ukrainian
-      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
+      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
       with:
         # Upload sources to Crowdin
         upload_sources: false

--- a/.github/workflows/remote-get-ukrainian-v6.yml
+++ b/.github/workflows/remote-get-ukrainian-v6.yml
@@ -87,7 +87,7 @@ jobs:
 
     # Runs the Crowdin action command - https://github.com/crowdin/github-action
     - name: Crowdin Upload Ukrainian
-      uses: crowdin/github-action@e4a6c1338b4063c77d46a81875265f9e8bd76f95 # v3.0.0
+      uses: crowdin/github-action@ce33ce793a5cbc401d9cd748716e03fc90c001f1 # v2.15.2
       with:
         # Upload sources to Crowdin
         upload_sources: false


### PR DESCRIPTION
## Summary

Pins every GitHub Action in this repository to a full-length commit SHA, using [pinact](https://github.com/suzuki-shunsuke/pinact) — the same approach already used in `joomla/joomla-cms`.

This is a prerequisite for enabling **Settings → Actions → "Require actions to be pinned to a full-length commit SHA"** on the organisation/repository. Without it, that setting would immediately break every workflow here.

## Why

A mutable tag (`@v6`) or branch ref can be repointed by the action's maintainer — or by anyone who compromises that account — to arbitrary code, which then runs in our workflows with access to `CROWDIN_PERSONAL_TOKEN`, `CROWDIN_PROJECT_ID` and `GHA_TRANSLATIONBOT_PAT`. A commit SHA is immutable, so what we reviewed is exactly what runs.

## What changed

All 29 workflow files, 7 distinct actions. Each `uses:` keeps a trailing comment with the human-readable version so the diff stays reviewable:

| Action | Before | Pinned to |
|---|---|---|
| `actions/checkout` | `@v6` | `3d3c42e5aac5ba805825da76410c181273ba90b1` # v7.0.1 |
| `actions/upload-artifact` | `@v7` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` # v7.0.1 |
| `crowdin/github-action` | `@v2.15.2` | `ce33ce793a5cbc401d9cd748716e03fc90c001f1` # v2.15.2 |
| `fjogeleit/http-request-action` | `@v2.0.0` | `f98bb26551cd1af7d3eb2674578a80754ece88db` # v2.0.1 |
| `marocchino/on_artifact` | `@v2` | `15ee6e49e31cdbc538ee54332436e6de32c809a3` # v2.0.0 |
| `marocchino/sticky-pull-request-comment` | `@v3` | `5770ad5eb8f42dd2c4f34da00c94c5381e49af88` # v3.0.5 |
| `StephaneBour/actions-php-lint` | `@8.4` | `e81e93ef8d421a09e434b715766a89679dd974dc` # 8.4 |

Every SHA was verified against the upstream tag via the GitHub API.

### Notes on version changes

Pinning resolves floating majors to whatever they currently point at, so two actions move to a newer release as a side effect:

- **`actions/checkout` v6 → v7.0.1** — the v7 major only blocks checking out fork PR refs under `pull_request_target` / `workflow_run` (not used here) and moves to Node 24. No impact on these workflows.
- **`crowdin/github-action` stays at v2.15.2.** v3.0.0 (new Crowdin CLI 5) was released the same day this PR was prepared. It is technically compatible — its breaking changes only affect the `command_args` / `*_args` inputs, which we don't use — but since this action drives the entire translation pipeline, it is deliberately left at the version currently running. The v3 upgrade should be its own PR so it can be watched on a single nightly run.

`marocchino/on_artifact` and `sticky-pull-request-comment` were already floating on the major that the pinned SHA belongs to, so their behaviour is unchanged.

## Follow-up

Dependabot is already configured for `github-actions` in `.github/dependabot.yml` and understands SHA pins — it will keep both the SHA and the version comment updated, so this does not freeze us on old versions.

After this is merged, **"Require actions to be pinned to a full-length commit SHA"** can be enabled.

## Testing

- All 29 workflow files verified to still parse as valid YAML.
- Each pinned SHA confirmed to be the commit behind the tag named in its comment.
- No workflow logic, inputs, triggers or schedules were changed — the diff is `uses:` lines only.
